### PR TITLE
Add wikiapiary

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2126,6 +2126,13 @@
 			"extensions": [
 				"Cargo"
 			]
+		},
+		{
+			"name": "wikiapiary.com",
+			"regex": "((?:www\\.)?wikiapiary\\.com",
+			"articlePath": "/wiki/",
+			"scriptPath": "/w/",
+			"fullScriptPath": "https://wikiapiary.com/w/"
 		}
 	]
 }


### PR DESCRIPTION
Addition of Wikiapiary.com has been requested for few years and now they have upgraded to MediaWiki 1.39, I think there's no blocker left and can finally be added.