### PR TITLE
Update projects.json

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -693,13 +693,6 @@
 			"wikiFarm": "huijiwiki"
 		},
 		{
-			"name": "incels.wiki",
-			"regex": "((?:www\\.)?incels\\.wiki)",
-			"articlePath": "/w/",
-			"scriptPath": "/",
-			"fullScriptPath": "https://incels.wiki/"
-		},
-		{
 			"name": "jojowiki.com",
 			"regex": "((?:www\\.)?jojowiki\\.com)",
 			"articlePath": "/",


### PR DESCRIPTION
Having dedicated support for the Incel Wiki in Wiki-Bot likely violates Discord's Terms of Service, specifically the Community Guidelines, and may also violate copyright. The wiki covers the subculture from an incel perspective, characterized by misogyny, racism, rape culture, and violent extremism, among other things. While the main page says, "The Incel Wiki does not condone the violence committed by [mass shooters and other criminals]", [the Wikipedia article on the term](https://en.wikipedia.org/wiki/Incel) notes that "[o]ver time the subculture has become associated with extremism and terrorism, and since 2014 there have been multiple mass killings, mostly in North America, perpetrated by self-identified incels, as well as other instances of violence or attempted violence."

By supporting this wiki, Wiki-Bot violates the [Hateful Conduct Policy](https://discord.com/safety/hateful-conduct-policy-explainer) and the [Violent Extremism Policy](https://discord.com/safety/violent-extremism-policy-explainer), including most things listed under the "For example, you may not post, share, or engage in:" dropdowns in the _Hate Speech_ and _Violent Extremism_ sections. See literally any article on the Incel Wiki for examples of this.

In addition, the wiki's licensing is somewhat unclear, but it appears to be "all rights reserved" or similar, judging by the about page. This is further supported by the general disclaimer. As such, Wiki-Bot using excerpts from this wiki appears to constitute a copyright violation, as not all uses of the bot can be considered fair use with regard to wiki content.