### PR TITLE
Update detection for Animal Royale wikis

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1774,7 +1774,7 @@
 			"idString": {
 				"regex": "([a-z-]{2,12})",
 				"scriptPaths": [
-					"https://$1.wiki.animalroyale.com/"
+					"https://$1.wiki.animalroyale.com/w/"
 				]
 			}
 			"wikiFarm": "miraheze",

--- a/projects.json
+++ b/projects.json
@@ -1768,10 +1768,15 @@
 		},
 		{
 			"name": "wiki.animalroyale.com",
-			"regex": "(wiki\\.animalroyale\\.com)",
+			"regex": "((?:([a-z-]{2,12})\\.)?wiki\\.animalroyale\\.com)",
 			"articlePath": "/wiki/",
 			"scriptPath": "/w/",
-			"fullScriptPath": "https://wiki.animalroyale.com/w/",
+			"idString": {
+				"regex": "([a-z-]{2,12})",
+				"scriptPaths": [
+					"https://$1.wiki.animalroyale.com/"
+				]
+			}
 			"wikiFarm": "miraheze",
 			"extensions": [
 				"CentralAuth",


### PR DESCRIPTION
Since Animal Royale wikis now have language variants, I've updated the entry for Animal Royale wiki to support URLs of languages wikis such as https://zh.wiki.animalroyale.com/ in addition to existing https://wiki.animalroyale.com