### PR TITLE
Add support for es.deltarune.wiki

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mediawiki-projects-list",
-  "version": "4.9.3",
+  "version": "4.9.4",
   "type": "commonjs",
   "description": "List of MediaWiki projects for use in discord-wiki-bot",
   "main": "index.js",

--- a/projects.json
+++ b/projects.json
@@ -385,10 +385,15 @@
 		},
 		{
 			"name": "deltarune.wiki",
-			"regex": "(deltarune\\.wiki)",
+			"regex": "((?:([a-z-]{2,12})\\.)?deltarune\\.wiki)",
 			"articlePath": "/w/",
 			"scriptPath": "/",
-			"fullScriptPath": "https://deltarune.wiki/",
+			"idString": {
+				"regex": "([a-z-]{2,12})",
+				"scriptPaths": [
+					"https://$1.deltarune.wiki/"
+				]
+			},
 			"wikiFarm": "undertale",
 			"extensions": [
 				"OAuth"
@@ -1651,10 +1656,15 @@
 		},
 		{
 			"name": "undertale.wiki",
-			"regex": "(undertale\\.wiki)",
+			"regex": "((?:([a-z-]{2,12})\\.)?undertale\\.wiki)",
 			"articlePath": "/w/",
 			"scriptPath": "/",
-			"fullScriptPath": "https://undertale.wiki/",
+			"idString": {
+				"regex": "([a-z-]{2,12})",
+				"scriptPaths": [
+					"https://$1.undertale.wiki/"
+				]
+			},
 			"wikiFarm": "undertale",
 			"extensions": [
 				"OAuth"


### PR DESCRIPTION
We recently added some new language subdomains over at Undertale and Deltarune wikis, and they had problems adding their wiki over at Wiki-Bot, so I assume they need to be accounted for in here. I copied these objects from `minecraft.wiki`, no idea what's the deal with `idString`.

The English wiki doesn't run on a subdomain, so I'm not sure how will this work for the English wiki. But I added an `en.deltarune.wiki` redirect just in case.