### PR TITLE
Adding support for Vietnamese Cookie Run Wiki

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mediawiki-projects-list",
-  "version": "4.9.8",
+  "version": "4.9.9",
   "type": "commonjs",
   "description": "List of known MediaWiki projects for use in discord-wiki-bot",
   "main": "index.js",

--- a/projects.json
+++ b/projects.json
@@ -357,10 +357,15 @@
 		},
 		{
 			"name": "cookierun.wiki",
-			"regex": "(cookierun\\.wiki)",
+			"regex": "((?:([a-z-]{2,12})\\.)?cookierun\\.wiki)",
 			"articlePath": "/w/",
 			"scriptPath": "/mw/",
-			"fullScriptPath": "https://cookierun.wiki/mw/",
+			"idString": {
+				"regex": "([a-z-]{2,12})",
+				"scriptPaths": [
+					"https://$1.cookierun.wiki/"
+				]
+			},
 			"extensions": [
 				"OAuth"
 			]


### PR DESCRIPTION
Fixing the missing script path that causes unwanted redirects when adding viwiki to Wiki-Bot (per PR #21)